### PR TITLE
Fix timezone comparison in filter function

### DIFF
--- a/pr_nudge.py
+++ b/pr_nudge.py
@@ -56,7 +56,9 @@ def fetch_prs(
 def filter_stale(
     prs: Iterable[dict], stale_days: int, *, exclude_labels: set[str] | None = None
 ) -> list[dict]:
-    cutoff = dt.datetime.utcnow() - dt.timedelta(days=stale_days)
+    cutoff = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc) - dt.timedelta(
+        days=stale_days
+    )
     stale: list[dict] = []
     labels = exclude_labels or set()
     for pr in prs:


### PR DESCRIPTION
## Summary
- avoid mixing timezone-aware and naive datetimes in `filter_stale`

## Testing
- `ruff check pr_nudge.py`
- `black --check .`
- `pytest -q` *(fails: command not found)*